### PR TITLE
fix etc permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,10 @@ WORKDIR /tmp
 
 COPY ./docker/start.sh /start.sh
 
+RUN chgrp 0 /etc &&  \
+    chmod g+w /etc && \
+    chgrp 0 /etc/passwd &&  \
+    chmod g+w /etc/passwd
 
 RUN chgrp 0 /var/lib/pgsql/ && chmod g+w /var/lib/pgsql/ && chmod 777 /var/lib/pgsql && \
     chgrp 0 /var/run/postgresql/ && chmod g+w /var/run/postgresql/ && chmod 777 /var/run/postgresql && \


### PR DESCRIPTION
For openshift cluster, got below error in major-upgrade pod logs -

[2025-04-16T06:08:51] starting as not postgres user
[2025-04-16T06:08:51] Adding randomly generated uid to passwd file...
sed: couldn't open temporary file /etc/sed57zupW: Permission denied

Due to this issue major upgrade pod ended with error and major upgrade procedure was broken.